### PR TITLE
Trigger EnterZone.After only when entering

### DIFF
--- a/ActionHook.cs
+++ b/ActionHook.cs
@@ -17,6 +17,10 @@ internal static class ModInfo
 internal class ActionHook : BaseUnityPlugin
 {
   internal static ActionHook Instance { get; private set; }
+  
+  // Zone.Activate is called even when the player loads the game.
+  // To avoid triggering EnterZone.After event on loading, check this flag.
+  public static bool IsEnteringZone { get; set; } = false;
 
   Dictionary<Events.EventBase, List<Actions.ActionBase>> Actions { get; set; } = null;
 

--- a/Patch.cs
+++ b/Patch.cs
@@ -9,6 +9,8 @@ public static class PatchForEnterZone
   [HarmonyPrefix, HarmonyPatch(typeof(Player), nameof(Player.EnterLocalZone), new Type[] { typeof(Point), typeof(ZoneTransition), typeof(bool), typeof(Chara) })]
   public static void Player_EnterLocalZone_Prefix(Point p)
   {
+    ActionHook.IsEnteringZone = true;
+
     p = p.Copy();
     if (EClass._zone.IsRegion)
     {
@@ -29,6 +31,12 @@ public static class PatchForEnterZone
   [HarmonyPostfix, HarmonyPatch(typeof(Zone), nameof(Zone.Activate))]
   public static void Zone_Activate_Postfix(Zone __instance)
   {
+    if (!ActionHook.IsEnteringZone)
+    {
+      return;
+    }
+    ActionHook.IsEnteringZone = false;
+
     var zone = __instance;
     var subType = zoneToSubType(zone);
 
@@ -70,6 +78,8 @@ public static class PatchForStairs
   [HarmonyPrefix, HarmonyPatch(typeof(TraitNewZone), nameof(TraitNewZone.MoveZone))]
   public static void TraitNewZone_MoveZone_Prefix(TraitNewZone __instance)
   {
+    ActionHook.IsEnteringZone = true;
+
     if (__instance is TraitStairsDown)
     {
       var ev = new Events.GoDownStairs { Phase = Events.Phase.Before };


### PR DESCRIPTION
Zone.Activate is called even if the player loads the game. To avoid triggering the event on loading, check a flag.