### PR TITLE
Fix error when opening quick craft

### DIFF
--- a/Patch.cs
+++ b/Patch.cs
@@ -111,7 +111,7 @@ public static class PatchForStartCrafting
 
   static void triggerEvent(Card t)
   {
-    var skill = t.trait.GetParam(1) ?? "handicraft";
+    var skill = t?.trait?.GetParam(1) ?? "handicraft";
     skill = char.ToUpper(skill[0]) + skill.Substring(1);
     if (!Enum.TryParse(skill, out Events.SubType subType))
     {


### PR DESCRIPTION
It throws an error when the player opens the quick craft because quick craft does not have an owner.

